### PR TITLE
Check if get was successful before trying to set some config.

### DIFF
--- a/foscam/foscam.py
+++ b/foscam/foscam.py
@@ -613,20 +613,25 @@ class FoscamCamera(object):
         Get the current config and set the motion detection on or off
         '''
         result, current_config = self.get_motion_detect_config()
+        if result != FOSCAM_SUCCESS:
+            return result
         current_config['isEnable'] = enabled
         self.set_motion_detect_config(current_config)
+        return FOSCAM_SUCCESS
 
     def enable_motion_detection(self):
         '''
         Enable motion detection
         '''
-        self.set_motion_detection(1)
+        result = self.set_motion_detection(1)
+        return result
 
     def disable_motion_detection(self):
         '''
         disable motion detection
         '''
-        self.set_motion_detection(0)
+        result = self.set_motion_detection(0)
+        return result
 
     def get_alarm_record_config(self, callback=None):
         '''


### PR DESCRIPTION
In the set_motion_detection() function, the code is getting the current configuration, and then enabling/disabling the motion detection flag accordingly.  The code is not checking if the get succeeded before trying to set the configuration.

Example, in a case where the foscam camera is not communicable, then if we try to give enable_motion_detection, then it will report an error that unable to set the "isEnable" flag etc.  

This check fixes that error.