### PR TITLE
Make import relative

### DIFF
--- a/foscam/__init__.py
+++ b/foscam/__init__.py
@@ -1,2 +1,2 @@
-from foscam import FoscamCamera
+from .foscam import FoscamCamera
 


### PR DESCRIPTION
The `foscam` namespace is pointing at the actual package, and thus at the `__init__.py` file itself. Importing from the `foscam` relative file is done by either changing it to a relative import: `from .foscam import FoscamCamera` or to point it to an absolute import: `from foscam.foscam import FoscamCamera`.

The relative one is a neater solution so that's what this PR does. This was reported before but incorrectly closed #15 