### PR TITLE
Add motion detection API calls for FI9900P line of foscam cameras.

### DIFF
--- a/foscam/foscam.py
+++ b/foscam/foscam.py
@@ -633,6 +633,40 @@ class FoscamCamera(object):
         result = self.set_motion_detection(0)
         return result
 
+	# These API calls support FI9900P devices, which use a different CGI command
+    def get_motion_detect_config1(self, callback=None):
+        '''
+        Get motion detect config
+        '''
+        return self.execute_command('getMotionDetectConfig1', callback=callback)
+
+    def set_motion_detect_config1(self, params, callback=None):
+        '''
+        Get motion detect config
+        '''
+        return self.execute_command('setMotionDetectConfig1', params, callback=callback)
+
+    def set_motion_detection1(self, enabled=1):
+        '''
+        Get the current config and set the motion detection on or off
+        '''
+        result, current_config = self.get_motion_detect_config1()
+        current_config['isEnable'] = enabled
+        self.set_motion_detect_config1(current_config)
+
+    def enable_motion_detection1(self):
+        '''
+        Enable motion detection
+        '''
+        self.set_motion_detection1(1)
+
+    def disable_motion_detection1(self):
+        '''
+        disable motion detection
+        '''
+        self.set_motion_detection1(0)
+
+		
     def get_alarm_record_config(self, callback=None):
         '''
         Get alarm record config
@@ -765,3 +799,5 @@ class FoscamCamera(object):
         '''
         params = {'offset': offset, 'count': count}
         return self.execute_command('getLog', params, callback=callback)
+		
+

--- a/foscam/foscam.py
+++ b/foscam/foscam.py
@@ -6,9 +6,9 @@ A module to exploit Foscam Foscam FI9821W/P/HD816W/P camera.
 
 # Python 3 support. Also print -> print().
 try:
-    from urllib import urlopen
+    from urllib import urlopen    
 except ImportError:
-    from urllib.request import urlopen
+    from urllib.request import urlopen   
 try:
     from urllib import urlencode
 except ImportError:
@@ -25,6 +25,8 @@ try:
     ssl_enabled=True
 except ImportError:
     ssl_enabled=False
+
+from collections import OrderedDict
 
 # Foscam error code.
 FOSCAM_SUCCESS           = 0
@@ -107,7 +109,7 @@ class FoscamCamera(object):
                 print ('Foscam exception: ' + raw_string)
             return ERROR_FOSCAM_UNAVAILABLE, None
         code = ERROR_FOSCAM_UNKNOWN
-        params = dict()
+        params = OrderedDict()
         for child in root.iter():
             if child.tag == 'result':
                 code = int(child.text)

--- a/foscam/foscam.py
+++ b/foscam/foscam.py
@@ -13,6 +13,11 @@ try:
     from urllib import urlencode
 except ImportError:
     from urllib.parse import urlencode
+try:
+    from urllib import unquote
+except ImportError:
+    from urllib.parse import unquote
+
 import xml.etree.ElementTree as ET
 from threading import Thread
 try:
@@ -108,7 +113,7 @@ class FoscamCamera(object):
                 code = int(child.text)
 
             elif child.tag != 'CGI_Result':
-                params[child.tag] = child.text
+                params[child.tag] = unquote(child.text)
 
         if self.verbose:
             print ('Received Foscam response: %s, %s' % (code, params))
@@ -633,7 +638,7 @@ class FoscamCamera(object):
         result = self.set_motion_detection(0)
         return result
 
-	# These API calls support FI9900P devices, which use a different CGI command
+    # These API calls support FI9900P devices, which use a different CGI command
     def get_motion_detect_config1(self, callback=None):
         '''
         Get motion detect config
@@ -666,7 +671,7 @@ class FoscamCamera(object):
         '''
         self.set_motion_detection1(0)
 
-		
+        
     def get_alarm_record_config(self, callback=None):
         '''
         Get alarm record config
@@ -786,7 +791,7 @@ class FoscamCamera(object):
         cmd: snapPicture2
         '''
         return self.execute_command('snapPicture2', {}, callback=callback, raw=True)
-
+               
     # ********************** Misc ****************************
 
     def get_log(self, offset, count=10, callback=None):
@@ -799,5 +804,5 @@ class FoscamCamera(object):
         '''
         params = {'offset': offset, 'count': count}
         return self.execute_command('getLog', params, callback=callback)
-		
+        
 

--- a/foscam/foscam.py
+++ b/foscam/foscam.py
@@ -791,7 +791,21 @@ class FoscamCamera(object):
         cmd: snapPicture2
         '''
         return self.execute_command('snapPicture2', {}, callback=callback, raw=True)
-               
+        
+    # ******************* SMTP Functions *********************
+    
+    def set_smtp_config(self, params, callback=None):
+        '''
+        Set smtp settings using the array of parameters 
+        '''
+        return self.execute_command('setSMTPConfig', params, callback=callback)
+        
+    def get_smtp_config(self, callback=None):
+        '''
+        Get smtp settings using the array of parameters 
+        '''
+        return self.execute_command('getSMTPConfig', callback=callback)
+        
     # ********************** Misc ****************************
 
     def get_log(self, offset, count=10, callback=None):


### PR DESCRIPTION
The FI9900P line of cameras uses the "getMotionDetectConfig1" command to access motion detection settings.  These API calls extend functionality so it works for these family of cameras as well.