### PR TITLE
Fix handing of XML response with type 'None"

### DIFF
--- a/foscam/foscam.py
+++ b/foscam/foscam.py
@@ -115,7 +115,9 @@ class FoscamCamera(object):
                 code = int(child.text)
 
             elif child.tag != 'CGI_Result':
-                params[child.tag] = unquote(child.text)
+                if type(child.text) == str:
+                    child.text = unquote(child.text)
+                params[child.tag] = child.text
 
         if self.verbose:
             print ('Received Foscam response: %s, %s' % (code, params))


### PR DESCRIPTION
Currently when this library receives a response back from the camera with an empty value, child.text is of type 'None', which causes unquote to throw an error. This modification only runs unquote if the value is a string.