### PR TITLE
Add timeout parameter so urlopen doesn't hang if camera is hung

### DIFF
--- a/foscam/foscam.py
+++ b/foscam/foscam.py
@@ -96,9 +96,9 @@ class FoscamCamera(object):
             raw_string = ''
             if self.ssl and ssl_enabled:
                 gcontext = ssl.SSLContext(ssl.PROTOCOL_TLSv1)  # disable cert
-                raw_string = urlopen(cmdurl,context=gcontext).read()
+                raw_string = urlopen(cmdurl,context=gcontext, timeout=5).read()
             else:
-                raw_string = urlopen(cmdurl).read()
+                raw_string = urlopen(cmdurl,timeout=5).read()
             if raw:
                 if self.verbose:
                     print ('Returning raw Foscam response: len=%d' % len(raw_string))
@@ -658,6 +658,8 @@ class FoscamCamera(object):
         Get the current config and set the motion detection on or off
         '''
         result, current_config = self.get_motion_detect_config1()
+        if result != FOSCAM_SUCCESS:
+            return result
         current_config['isEnable'] = enabled
         self.set_motion_detect_config1(current_config)
 


### PR DESCRIPTION
If the cameras are crashed or unresponsive, this causes the library to not respond.  Insert a default timeout parameter so that requests will timeout and return.

Also add a missing return status check in set_motion_detection1