### PR TITLE
Handle blank return values

### DIFF
--- a/foscam/foscam.py
+++ b/foscam/foscam.py
@@ -115,8 +115,10 @@ class FoscamCamera(object):
                 code = int(child.text)
 
             elif child.tag != 'CGI_Result':
-                params[child.tag] = unquote(child.text)
-
+                if child.text:
+                    params[child.tag] = unquote(child.text)
+                else:
+                    params[child.tag] = ""
         if self.verbose:
             print ('Received Foscam response: %s, %s' % (code, params))
         return code, params


### PR DESCRIPTION
Some newer foscams return blank for username and password for configured accounts (i.e. email credentials).  This fix handles this without crashing.