### PR TITLE
Add White Light Control for S41/SCP models

### DIFF
--- a/foscam/foscam.py
+++ b/foscam/foscam.py
@@ -492,6 +492,45 @@ class FoscamCamera(object):
         params = {'mode': mode}
         return self.execute_command('setInfraLedConfig', params, callback=callback)
 
+    def open_white_light(self, callback=None):
+        '''
+        Force open white light, set manual mode first using set_white_light_config
+        cmd: openWhiteLight
+        '''
+        return self.execute_command('openWhiteLight', {}, callback=callback)
+
+    def close_white_light(self, callback=None):
+        '''
+        Force close white light, set manual mode first using set_white_light_config
+        cmd: closeWhiteLight
+        '''
+        return self.execute_command('closeWhiteLight', callback=callback)
+
+    def get_white_light_config(self, callback=None):
+        '''
+        Get White Light configuration
+        cmd: getWhiteLightConfig
+        '''
+        return self.execute_command('getWhiteLightConfig', callback=callback)
+
+    def set_white_light_config(self, lightmode, callback=None):
+        '''
+        Set White Light configuration
+        cmd: setWhiteLightConfig
+        Lightmode(0,1): 0=Auto mode, 1=?, 2=Manual mode
+        '''
+        params = {'Lightmode': lightmode}
+        return self.execute_command('setWhiteLightConfig', params, callback=callback)
+
+    def set_night_light_state(self, state, callback=None):
+        '''
+        Set Night Light state
+        cmd: setNightLightState
+        state(0,1): 0=Off, 1=On
+        '''
+        params = {'state': state}
+        return self.execute_command('setNightLightState', params, callback=callback)
+
     def get_product_all_info(self, callback=None):
         '''
         Get camera information

--- a/tests/camtest.py
+++ b/tests/camtest.py
@@ -228,6 +228,22 @@ class TestFoscam(unittest.TestCase):
         rc, args = self.foscam.set_infra_led_config(1)
         self.assertEqual(rc, 0)
 
+    def test_open_white_light(self):
+        rc, args = self.foscam.open_white_light()
+        self.assertEqual(rc, 0)
+
+    def test_close_white_light(self):
+        rc, args = self.foscam.close_white_light()
+        self.assertEqual(rc, 0)
+
+    def test_get_white_light_config(self):
+        rc, args = self.foscam.get_white_light_config()
+        self.assertEqual(rc, 0)
+
+    def test_set_white_light_config(self):
+        rc, args = self.foscam.set_white_light_config(2)
+        self.assertEqual(rc, 0)
+
     def test_get_product_all_info(self):
         rc, args = self.foscam.get_product_all_info()
         self.assertEqual(rc, 0)


### PR DESCRIPTION
This update adds White light control to the S41/SCP bullet camera models. To control the light, the camera must be put in manual mode first.

Usage Example:
from foscam import FoscamCamera
from time import sleep

mycam = FoscamCamera(ip, port, user, pwd)
mycam.set_white_light_config(2)
mycam.open_white_light()
sleep(5)
mycam.close_white_light()
mycam.set_white_light_config(0)